### PR TITLE
Refactor

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,23 +4,22 @@ class UsersController < ApplicationController
 
   def new
     @user = User.new
-    @address = @user.addresses.new
   end
 
   def create
     @user = User.create(user_params)
-    #@new_address = Address.create(address_params)
+    @address = Address.create(address_params)
     if @user.save
-      @address = @user.addresses.create(address_params)
+      @user.addresses << @address
       if @address.save
         session[:user_id] = @user.id
         flash[:success] = "Welcome, #{@user.name}! You are now registered and logged in."
         redirect_to "/profile"
       end
     else
-      flash[:error] = @user.errors.full_messages.uniq.to_sentence
-      #flash[:error] = @new_address.errors.full_messages.uniq.to_sentence
-      render :new
+      flash[:error] = @address.errors.full_messages.uniq.to_sentence
+      flash[:success] = @user.errors.full_messages.uniq.to_sentence
+      render :new_2
     end
   end
 
@@ -40,8 +39,8 @@ class UsersController < ApplicationController
   end
 
   def update
-    @user.update(user_params)
-    if user_params.include?(:password)
+    @user.update(user_params_edit)
+    if user_params_edit.include?(:password) && @user.save
       redirect_to '/profile'
       flash[:success] = 'Your password has been updated'
     elsif @user.save
@@ -49,7 +48,7 @@ class UsersController < ApplicationController
       flash[:success] = 'Your profile has been updated'
     else
       redirect_to '/profile/edit'
-      flash[:error] = @user.errors.full_messages.uniq
+      flash[:error] = @user.errors.full_messages.uniq.to_sentence
     end
   end
 
@@ -57,6 +56,10 @@ class UsersController < ApplicationController
 
   def require_user
     render file: "/public/404" unless current_user
+  end
+
+  def user_params_edit
+    params.permit(:name, :email, :password, :password_confirmation)
   end
 
   def user_params

--- a/app/views/users/new_2.html.erb
+++ b/app/views/users/new_2.html.erb
@@ -15,12 +15,12 @@
 
 
 <%= form_for @user do |f| %>
-  <%= f.text_field :name, placeholder: "Name"%>
+  <%= f.text_field :name, value: @user.name, placeholder: "Name"%>
   <%= f.fields_for :address do |a| %>
-    <%= a.text_field :address, placeholder: "Address" %>
-    <%= a.text_field :city, placeholder: "City" %>
-    <%= a.text_field :state, placeholder: "State" %>
-    <%= a.text_field :zip, placeholder: "Zip" %>
+    <%= a.text_field :address, value: @address.address, placeholder: "Address" %>
+    <%= a.text_field :city, value: @address.city, placeholder: "City" %>
+    <%= a.text_field :state, value: @address.state, placeholder: "State" %>
+    <%= a.text_field :zip, value: @address.zip, placeholder: "Zip" %>
   <% end %>
   <%= f.text_field :email, value: nil, placeholder: "Email"%>
   <%= f.password_field :password, value: nil, placeholder: "Password"%>

--- a/spec/features/users/profile_spec.rb
+++ b/spec/features/users/profile_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe "User Profile" do
       end
     end
 
-    xit 'I click the Edit Profile link. I see a prepopulate form with my current info. I submit the form and am returned to my profile page with my new info.' do
+    it 'I click the Edit Profile link. I see a prepopulate form with my current info. I submit the form and am returned to my profile page with my new info.' do
       visit '/profile'
       click_link 'Edit Profile'
       expect(current_path).to eq('/profile/edit')
@@ -34,8 +34,8 @@ RSpec.describe "User Profile" do
       expect(find_field(:name).value).to eq(@user.name)
       expect(find_field(:email).value).to eq(@user.email)
 
-      name = 'Christopher'
-      email = 'christopher@email.com'
+      name = 'Christopher H'
+      email = 'christopher123456789@email.com'
 
       fill_in "Name", with: name
       fill_in "Email", with: email
@@ -45,14 +45,10 @@ RSpec.describe "User Profile" do
 
       expect(page).to have_content('Your profile has been updated')
       expect(page).to have_content(name)
-      expect(page).to have_content(address)
-      expect(page).to have_content(city)
-      expect(page).to have_content(state)
-      expect(page).to have_content(zip)
       expect(page).to have_content(email)
     end
 
-    xit 'I see a link to edit my password. I fill out the form and am returned to my profile. I see a flash message confirming the update.' do
+    it 'I see a link to edit my password. I fill out the form and am returned to my profile. I see a flash message confirming the update.' do
       visit '/profile'
       click_link 'Edit Password'
 
@@ -70,7 +66,25 @@ RSpec.describe "User Profile" do
       expect(page).to have_content('Your password has been updated')
     end
 
-    xit 'I must use a unique email address when updating my profile' do
+    it 'I have to give the same password in the password and password confirmation fields' do
+      visit '/profile'
+      click_link 'Edit Password'
+
+      expect(current_path).to eq('/profile/password_edit')
+
+      password = 'password'
+      password_confirmation = 'password123456789'
+
+      fill_in :password, with: password
+      fill_in :password_confirmation, with: password_confirmation
+
+      click_button 'Submit'
+
+      expect(current_path).to eq('/profile/edit')
+      expect(page).to have_content("Password confirmation doesn't match Password")
+    end
+
+    it 'I must use a unique email address when updating my profile' do
       visit '/profile/edit'
 
       email = 'ck@email.com'

--- a/spec/features/users/register_spec.rb
+++ b/spec/features/users/register_spec.rb
@@ -47,7 +47,7 @@ describe 'User Registration' do
       expect(page).to have_content("Zip Code: #{zip}")
     end
 
-    xit 'they have to fill out entire form' do
+    it 'they have to fill out entire form' do
 
       visit '/register'
       name = "alec"


### PR DESCRIPTION
- Enable hiding of password fields in new user registration and password edit fields
- Add appropriate flash error messages when a user and address cannot be created during user registration
- Modify user controller to handle solely user params when editing user/password information
